### PR TITLE
Update contact info

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,5 @@
 # Made with love by Typo from TypoCreates (https://typocreates.com/#)
-# Report bugs to me on Discord or Spigot <3 (@TypoWasTaken).#
+# Report bugs to me on Github <3.#
 
 
 # Do you want to play a sound whenever you receive a message such as when you switch someone's gamemode?


### PR DESCRIPTION
Update contact info in the default config.yml to not include Discord or Spigot as contact options and instead have Github as the preferred contact option.