### PR TITLE
Centralize Strings

### DIFF
--- a/src/main/java/com/typocreates/gamemodes/commands/GmaCommand.java
+++ b/src/main/java/com/typocreates/gamemodes/commands/GmaCommand.java
@@ -7,7 +7,6 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.checkerframework.checker.nullness.qual.NonNull;
 
 public class GmaCommand implements CommandExecutor {
     private final GeneralUtil gu;
@@ -20,31 +19,31 @@ public class GmaCommand implements CommandExecutor {
     @Override
     public boolean onCommand(CommandSender commandSender, Command command, String s, String[] strings) {
         String gamemode = "Adventure";
-        String targetGamemodeChangeMessage = "Your gamemode has been set to {gm}.".replace("{gm}", gamemode);
-        String confirmationMessage = "%s's gamemode has been set to {gm}.".replace("{gm}", gamemode);
-        String senderNotPlayerMessage = "You either have to be a player or target a player to use this command.";
-        String playerNotFoundMessage = "That player could not be found, maybe they went offline?";
-        String tooManyArgsMessage = "You can only have a maximum of 1 argument for this command.";
-        String unableToChangeGamemode = "Unable to change that users gamemode! Their gamemode is currently locked!";
-        String gamemodeChangeNotAllowed = "That user isn't allowed in {gm}!".replace("{gm}", gamemode);
+        String targetGamemodeChangeMsg = gu.getTargetGamemodeChangeMsg().replace("{gm}", gamemode);
+        String confirmationMsg = gu.getConfirmationMsg().replace("{gm}", gamemode);
+        String senderNotPlayerMsg = gu.getSenderNotPlayerMsg();
+        String playerNotFoundMsg = gu.getPlayerNotFoundMsg();
+        String tooManyArgsMsg = gu.getTooManyArgsMsg();
+        String unableToChangeGamemodeMsg = gu.getUnableToChangeGamemodeMsg();
+        String gamemodeChangeNotAllowedMsg = gu.getGamemodeChangeNotAllowedMsg().replace("{gm}", gamemode);
 
 
 //        If there are no args, set players gamemode, if the commandSender isn't a player, send error.
         if (strings.length == 0) {
             if (commandSender instanceof Player player) {
                 if (gmLockData.isLocked(player.getUniqueId())) {
-                    gu.sendErrorMessage(player, unableToChangeGamemode);
+                    gu.sendErrorMessage(player, unableToChangeGamemodeMsg);
                     return true;
                 }
                 if (gu.isGamemodeBlocked(player, GameMode.ADVENTURE)) {
-                    gu.sendErrorMessage(commandSender, gamemodeChangeNotAllowed);
+                    gu.sendErrorMessage(commandSender, gamemodeChangeNotAllowedMsg);
                     return true;
                 }
-                gu.sendMessage(player, targetGamemodeChangeMessage);
+                gu.sendMessage(player, targetGamemodeChangeMsg);
                 player.setGameMode(GameMode.ADVENTURE);
                 return true;
             }
-            gu.sendMessage(commandSender, senderNotPlayerMessage);
+            gu.sendMessage(commandSender, senderNotPlayerMsg);
             return true;
         }
 
@@ -52,27 +51,27 @@ public class GmaCommand implements CommandExecutor {
         if (strings.length == 1) {
             Player target = Bukkit.getServer().getPlayer(strings[0]);
             if (target == null) {
-                gu.sendErrorMessage(commandSender, playerNotFoundMessage);
+                gu.sendErrorMessage(commandSender, playerNotFoundMsg);
                 return true;
             }
             if (gmLockData.isLocked(target.getUniqueId())) {
-                gu.sendErrorMessage(commandSender, unableToChangeGamemode);
+                gu.sendErrorMessage(commandSender, unableToChangeGamemodeMsg);
                 return true;
             }
             if (gu.isGamemodeBlocked(target, GameMode.ADVENTURE)) {
-                gu.sendErrorMessage(commandSender, gamemodeChangeNotAllowed);
+                gu.sendErrorMessage(commandSender, gamemodeChangeNotAllowedMsg);
                 return true;
             }
             target.setGameMode(GameMode.ADVENTURE);
-            gu.sendMessage(commandSender, String.format(confirmationMessage, target.getName()));
+            gu.sendMessage(commandSender, String.format(confirmationMsg, target.getName()));
             if (gu.sendTarget() && commandSender != target) {
-                gu.sendMessage(target, targetGamemodeChangeMessage);
+                gu.sendMessage(target, targetGamemodeChangeMsg);
             }
             return true;
         }
 
 //        If there is more than one arg, send error
-        gu.sendErrorMessage(commandSender, tooManyArgsMessage);
+        gu.sendErrorMessage(commandSender, tooManyArgsMsg);
         return true;
     }
 }

--- a/src/main/java/com/typocreates/gamemodes/commands/GmcCommand.java
+++ b/src/main/java/com/typocreates/gamemodes/commands/GmcCommand.java
@@ -7,7 +7,6 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.checkerframework.checker.nullness.qual.NonNull;
 
 public class GmcCommand implements CommandExecutor {
     private final GeneralUtil gu;
@@ -20,31 +19,31 @@ public class GmcCommand implements CommandExecutor {
     @Override
     public boolean onCommand(CommandSender commandSender, Command command, String s, String[] strings) {
         String gamemode = "Creative";
-        String targetGamemodeChangeMessage = "Your gamemode has been set to {gm}.".replace("{gm}", gamemode);
-        String confirmationMessage = "%s's gamemode has been set to {gm}.".replace("{gm}", gamemode);
-        String senderNotPlayerMessage = "You either have to be a player or target a player to use this command.";
-        String playerNotFoundMessage = "That player could not be found, maybe they went offline?";
-        String tooManyArgsMessage = "You can only have a maximum of 1 argument for this command.";
-        String unableToChangeGamemode = "Unable to change that users gamemode! Their gamemode is currently locked!";
-        String gamemodeChangeNotAllowed = "That user isn't allowed in {gm}!".replace("{gm}", gamemode);
+        String targetGamemodeChangeMsg = gu.getTargetGamemodeChangeMsg().replace("{gm}", gamemode);
+        String confirmationMsg = gu.getConfirmationMsg().replace("{gm}", gamemode);
+        String senderNotPlayerMsg = gu.getSenderNotPlayerMsg();
+        String playerNotFoundMsg = gu.getPlayerNotFoundMsg();
+        String tooManyArgsMsg = gu.getTooManyArgsMsg();
+        String unableToChangeGamemodeMsg = gu.getUnableToChangeGamemodeMsg();
+        String gamemodeChangeNotAllowedMsg = gu.getGamemodeChangeNotAllowedMsg().replace("{gm}", gamemode);
 
 
 //        If there are no args, set players gamemode, if the commandSender isn't a player, send error.
         if (strings.length == 0) {
             if (commandSender instanceof Player player) {
                 if (gmLockData.isLocked(player.getUniqueId())) {
-                    gu.sendErrorMessage(player, unableToChangeGamemode);
+                    gu.sendErrorMessage(player, unableToChangeGamemodeMsg);
                     return true;
                 }
                 if (gu.isGamemodeBlocked(player, GameMode.CREATIVE)) {
-                    gu.sendErrorMessage(commandSender, gamemodeChangeNotAllowed);
+                    gu.sendErrorMessage(commandSender, gamemodeChangeNotAllowedMsg);
                     return true;
                 }
-                gu.sendMessage(player, targetGamemodeChangeMessage);
+                gu.sendMessage(player, targetGamemodeChangeMsg);
                 player.setGameMode(GameMode.CREATIVE);
                 return true;
             }
-            gu.sendMessage(commandSender, senderNotPlayerMessage);
+            gu.sendMessage(commandSender, senderNotPlayerMsg);
             return true;
         }
 
@@ -52,27 +51,27 @@ public class GmcCommand implements CommandExecutor {
         if (strings.length == 1) {
             Player target = Bukkit.getServer().getPlayer(strings[0]);
             if (target == null) {
-                gu.sendErrorMessage(commandSender, playerNotFoundMessage);
+                gu.sendErrorMessage(commandSender, playerNotFoundMsg);
                 return true;
             }
             if (gmLockData.isLocked(target.getUniqueId())) {
-                gu.sendErrorMessage(commandSender, unableToChangeGamemode);
+                gu.sendErrorMessage(commandSender, unableToChangeGamemodeMsg);
                 return true;
             }
             if (gu.isGamemodeBlocked(target, GameMode.CREATIVE)) {
-                gu.sendErrorMessage(commandSender, gamemodeChangeNotAllowed);
+                gu.sendErrorMessage(commandSender, gamemodeChangeNotAllowedMsg);
                 return true;
             }
             target.setGameMode(GameMode.CREATIVE);
-            gu.sendMessage(commandSender, String.format(confirmationMessage, target.getName()));
+            gu.sendMessage(commandSender, String.format(confirmationMsg, target.getName()));
             if (gu.sendTarget() && commandSender != target) {
-                gu.sendMessage(target, targetGamemodeChangeMessage);
+                gu.sendMessage(target, targetGamemodeChangeMsg);
             }
             return true;
         }
 
 //        If there is more than one arg, send error
-        gu.sendErrorMessage(commandSender, tooManyArgsMessage);
+        gu.sendErrorMessage(commandSender, tooManyArgsMsg);
         return true;
     }
 }

--- a/src/main/java/com/typocreates/gamemodes/commands/GmsCommand.java
+++ b/src/main/java/com/typocreates/gamemodes/commands/GmsCommand.java
@@ -7,7 +7,6 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.checkerframework.checker.nullness.qual.NonNull;
 
 public class GmsCommand implements CommandExecutor {
     private final GeneralUtil gu;
@@ -20,31 +19,31 @@ public class GmsCommand implements CommandExecutor {
     @Override
     public boolean onCommand(CommandSender commandSender, Command command, String s, String[] strings) {
         String gamemode = "Survival";
-        String targetGamemodeChangeMessage = "Your gamemode has been set to {gm}.".replace("{gm}", gamemode);
-        String confirmationMessage = "%s's gamemode has been set to {gm}.".replace("{gm}", gamemode);
-        String senderNotPlayerMessage = "You either have to be a player or target a player to use this command.";
-        String playerNotFoundMessage = "That player could not be found, maybe they went offline?";
-        String tooManyArgsMessage = "You can only have a maximum of 1 argument for this command.";
-        String unableToChangeGamemode = "Unable to change that users gamemode! Their gamemode is currently locked!";
-        String gamemodeChangeNotAllowed = "That user isn't allowed in {gm}!".replace("{gm}", gamemode);
+        String targetGamemodeChangeMsg = gu.getTargetGamemodeChangeMsg().replace("{gm}", gamemode);
+        String confirmationMsg = gu.getConfirmationMsg().replace("{gm}", gamemode);
+        String senderNotPlayerMsg = gu.getSenderNotPlayerMsg();
+        String playerNotFoundMsg = gu.getPlayerNotFoundMsg();
+        String tooManyArgsMsg = gu.getTooManyArgsMsg();
+        String unableToChangeGamemodeMsg = gu.getUnableToChangeGamemodeMsg();
+        String gamemodeChangeNotAllowedMsg = gu.getGamemodeChangeNotAllowedMsg().replace("{gm}", gamemode);
 
 
 //        If there are no args, set players gamemode, if the commandSender isn't a player, send error.
         if (strings.length == 0) {
             if (commandSender instanceof Player player) {
                 if (gmLockData.isLocked(player.getUniqueId())) {
-                    gu.sendErrorMessage(player, unableToChangeGamemode);
+                    gu.sendErrorMessage(player, unableToChangeGamemodeMsg);
                     return true;
                 }
                 if (gu.isGamemodeBlocked(player, GameMode.SURVIVAL)) {
-                    gu.sendErrorMessage(commandSender, gamemodeChangeNotAllowed);
+                    gu.sendErrorMessage(commandSender, gamemodeChangeNotAllowedMsg);
                     return true;
                 }
-                gu.sendMessage(player, targetGamemodeChangeMessage);
+                gu.sendMessage(player, targetGamemodeChangeMsg);
                 player.setGameMode(GameMode.SURVIVAL);
                 return true;
             }
-            gu.sendMessage(commandSender, senderNotPlayerMessage);
+            gu.sendMessage(commandSender, senderNotPlayerMsg);
             return true;
         }
 
@@ -52,27 +51,27 @@ public class GmsCommand implements CommandExecutor {
         if (strings.length == 1) {
             Player target = Bukkit.getServer().getPlayer(strings[0]);
             if (target == null) {
-                gu.sendErrorMessage(commandSender, playerNotFoundMessage);
+                gu.sendErrorMessage(commandSender, playerNotFoundMsg);
                 return true;
             }
             if (gmLockData.isLocked(target.getUniqueId())) {
-                gu.sendErrorMessage(commandSender, unableToChangeGamemode);
+                gu.sendErrorMessage(commandSender, unableToChangeGamemodeMsg);
                 return true;
             }
             if (gu.isGamemodeBlocked(target, GameMode.SURVIVAL)) {
-                gu.sendErrorMessage(commandSender, gamemodeChangeNotAllowed);
+                gu.sendErrorMessage(commandSender, gamemodeChangeNotAllowedMsg);
                 return true;
             }
             target.setGameMode(GameMode.SURVIVAL);
-            gu.sendMessage(commandSender, String.format(confirmationMessage, target.getName()));
+            gu.sendMessage(commandSender, String.format(confirmationMsg, target.getName()));
             if (gu.sendTarget() && commandSender != target) {
-                gu.sendMessage(target, targetGamemodeChangeMessage);
+                gu.sendMessage(target, targetGamemodeChangeMsg);
             }
             return true;
         }
 
 //        If there is more than one arg, send error
-        gu.sendErrorMessage(commandSender, tooManyArgsMessage);
+        gu.sendErrorMessage(commandSender, tooManyArgsMsg);
         return true;
     }
 }

--- a/src/main/java/com/typocreates/gamemodes/commands/GmspCommand.java
+++ b/src/main/java/com/typocreates/gamemodes/commands/GmspCommand.java
@@ -7,7 +7,6 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.checkerframework.checker.nullness.qual.NonNull;
 
 public class GmspCommand implements CommandExecutor {
     private final GeneralUtil gu;
@@ -20,31 +19,31 @@ public class GmspCommand implements CommandExecutor {
     @Override
     public boolean onCommand(CommandSender commandSender, Command command, String s, String[] strings) {
         String gamemode = "Spectator";
-        String targetGamemodeChangeMessage = "Your gamemode has been set to {gm}.".replace("{gm}", gamemode);
-        String confirmationMessage = "%s's gamemode has been set to {gm}.".replace("{gm}", gamemode);
-        String senderNotPlayerMessage = "You either have to be a player or target a player to use this command.";
-        String playerNotFoundMessage = "That player could not be found, maybe they went offline?";
-        String tooManyArgsMessage = "You can only have a maximum of 1 argument for this command.";
-        String unableToChangeGamemode = "Unable to change that users gamemode! Their gamemode is currently locked!";
-        String gamemodeChangeNotAllowed = "That user isn't allowed in {gm}!".replace("{gm}", gamemode);
+        String targetGamemodeChangeMsg = gu.getTargetGamemodeChangeMsg().replace("{gm}", gamemode);
+        String confirmationMsg = gu.getConfirmationMsg().replace("{gm}", gamemode);
+        String senderNotPlayerMsg = gu.getSenderNotPlayerMsg();
+        String playerNotFoundMsg = gu.getPlayerNotFoundMsg();
+        String tooManyArgsMsg = gu.getTooManyArgsMsg();
+        String unableToChangeGamemodeMsg = gu.getUnableToChangeGamemodeMsg();
+        String gamemodeChangeNotAllowedMsg = gu.getGamemodeChangeNotAllowedMsg().replace("{gm}", gamemode);
 
 
 //        If there are no args, set players gamemode, if the commandSender isn't a player, send error.
         if (strings.length == 0) {
             if (commandSender instanceof Player player) {
                 if (gmLockData.isLocked(player.getUniqueId())) {
-                    gu.sendErrorMessage(player, unableToChangeGamemode);
+                    gu.sendErrorMessage(player, unableToChangeGamemodeMsg);
                     return true;
                 }
                 if (gu.isGamemodeBlocked(player, GameMode.SPECTATOR)) {
-                    gu.sendErrorMessage(commandSender, gamemodeChangeNotAllowed);
+                    gu.sendErrorMessage(commandSender, gamemodeChangeNotAllowedMsg);
                     return true;
                 }
-                gu.sendMessage(player, targetGamemodeChangeMessage);
+                gu.sendMessage(player, targetGamemodeChangeMsg);
                 player.setGameMode(GameMode.SPECTATOR);
                 return true;
             }
-            gu.sendMessage(commandSender, senderNotPlayerMessage);
+            gu.sendMessage(commandSender, senderNotPlayerMsg);
             return true;
         }
 
@@ -52,27 +51,27 @@ public class GmspCommand implements CommandExecutor {
         if (strings.length == 1) {
             Player target = Bukkit.getServer().getPlayer(strings[0]);
             if (target == null) {
-                gu.sendErrorMessage(commandSender, playerNotFoundMessage);
+                gu.sendErrorMessage(commandSender, playerNotFoundMsg);
                 return true;
             }
             if (gmLockData.isLocked(target.getUniqueId())) {
-                gu.sendErrorMessage(commandSender, unableToChangeGamemode);
+                gu.sendErrorMessage(commandSender, unableToChangeGamemodeMsg);
                 return true;
             }
             if (gu.isGamemodeBlocked(target, GameMode.SPECTATOR)) {
-                gu.sendErrorMessage(commandSender, gamemodeChangeNotAllowed);
+                gu.sendErrorMessage(commandSender, gamemodeChangeNotAllowedMsg);
                 return true;
             }
             target.setGameMode(GameMode.SPECTATOR);
-            gu.sendMessage(commandSender, String.format(confirmationMessage, target.getName()));
+            gu.sendMessage(commandSender, String.format(confirmationMsg, target.getName()));
             if (gu.sendTarget() && commandSender != target) {
-                gu.sendMessage(target, targetGamemodeChangeMessage);
+                gu.sendMessage(target, targetGamemodeChangeMsg);
             }
             return true;
         }
 
 //        If there is more than one arg, send error
-        gu.sendErrorMessage(commandSender, tooManyArgsMessage);
+        gu.sendErrorMessage(commandSender, tooManyArgsMsg);
         return true;
     }
 }

--- a/src/main/java/com/typocreates/gamemodes/utils/GeneralUtil.java
+++ b/src/main/java/com/typocreates/gamemodes/utils/GeneralUtil.java
@@ -46,4 +46,41 @@ public class GeneralUtil {
     public boolean sendTarget() {
         return plugin.getConfig().getBoolean("send-target-message", true);
     }
+
+    // Gamemode change strings
+    String targetGamemodeChangeMsg = "Your gamemode has been set to {gm}.";
+    String confirmationMsg = "%s's gamemode has been set to {gm}.";
+    String senderNotPlayerMsg = "You either have to be a player or target a player to use this command.";
+    String playerNotFoundMsg = "That player could not be found, maybe they went offline?";
+    String tooManyArgsMsg = "You can only have a maximum of 1 argument for this command.";
+    String unableToChangeGamemodeMsg = "Unable to change that users gamemode! Their gamemode is currently locked!";
+    String gamemodeChangeNotAllowedMsg = "That user isn't allowed in {gm}!";
+
+    public String getTargetGamemodeChangeMsg() {
+        return targetGamemodeChangeMsg;
+    }
+
+    public String getConfirmationMsg() {
+        return confirmationMsg;
+    }
+
+    public String getSenderNotPlayerMsg() {
+        return senderNotPlayerMsg;
+    }
+
+    public String getPlayerNotFoundMsg() {
+        return playerNotFoundMsg;
+    }
+
+    public String getTooManyArgsMsg() {
+        return tooManyArgsMsg;
+    }
+
+    public String getUnableToChangeGamemodeMsg() {
+        return unableToChangeGamemodeMsg;
+    }
+
+    public String getGamemodeChangeNotAllowedMsg() {
+        return gamemodeChangeNotAllowedMsg;
+    }
 }


### PR DESCRIPTION
### Centralize gamemode change strings

---

The goal is to make maintaining the strings that are used in each gamemode command easier, many of the strings are nearly identical in each command

This PR moves them to a centralized place (At the time of writing this, GeneralUtil)

Work was already done to prepare for this (making each command fill in it's gamemode on the fly rather than having it fully hard coded for each command)

For example, this string: `Your gamemode has been set to Survival.`

Is now: `Your gamemode has been set to {gm}.` with the gamemode being replaced where needed

Closes: #12 