### PR TITLE
Player update notifier

### DIFF
--- a/src/main/java/com/typocreates/gamemodes/Gamemodes.java
+++ b/src/main/java/com/typocreates/gamemodes/Gamemodes.java
@@ -1,7 +1,7 @@
 package com.typocreates.gamemodes;
 
 import com.typocreates.gamemodes.commands.*;
-import com.typocreates.gamemodes.files.GmLockData;
+import com.typocreates.gamemodes.data.GmLockData;
 import com.typocreates.gamemodes.listeners.PlayerGamemodeChangeListener;
 import com.typocreates.gamemodes.listeners.PlayerJoinListener;
 import com.typocreates.gamemodes.tabcompleters.GmLockTabCompleter;

--- a/src/main/java/com/typocreates/gamemodes/Gamemodes.java
+++ b/src/main/java/com/typocreates/gamemodes/Gamemodes.java
@@ -20,6 +20,7 @@ public final class Gamemodes extends JavaPlugin {
     private Gamemodes plugin;
     private GeneralUtil gu;
     private GmLockData gmLockData;
+    private UpdateChecker updateChecker;
 
 
     @Override
@@ -52,6 +53,7 @@ public final class Gamemodes extends JavaPlugin {
 //         Load config THEN set gu since it relies on the config
         saveDefaultConfig();
         gu = new GeneralUtil(this);
+        updateChecker = new UpdateChecker(this);
 
 //         Load the GamemodeLockData file
         gmLockData = new GmLockData(this);
@@ -72,10 +74,10 @@ public final class Gamemodes extends JavaPlugin {
 
         logger.info("Loading event listeners...");
         getServer().getPluginManager().registerEvents(new PlayerGamemodeChangeListener(gu, gmLockData), this);
-        getServer().getPluginManager().registerEvents(new PlayerJoinListener(this, gu), this);
+        getServer().getPluginManager().registerEvents(new PlayerJoinListener(this, gu, updateChecker), this);
         logger.info("Event listeners loaded!");
 
-        new UpdateChecker(this).checkUpdate();
+        updateChecker.checkUpdate();
 
         logger.info("Plugin fully loaded.");
 

--- a/src/main/java/com/typocreates/gamemodes/commands/GmLockCommand.java
+++ b/src/main/java/com/typocreates/gamemodes/commands/GmLockCommand.java
@@ -1,5 +1,5 @@
 package com.typocreates.gamemodes.commands;
-import com.typocreates.gamemodes.files.GmLockData;
+import com.typocreates.gamemodes.data.GmLockData;
 import com.typocreates.gamemodes.utils.GeneralUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;

--- a/src/main/java/com/typocreates/gamemodes/commands/GmUnlockCommand.java
+++ b/src/main/java/com/typocreates/gamemodes/commands/GmUnlockCommand.java
@@ -1,5 +1,5 @@
 package com.typocreates.gamemodes.commands;
-import com.typocreates.gamemodes.files.GmLockData;
+import com.typocreates.gamemodes.data.GmLockData;
 import com.typocreates.gamemodes.utils.GeneralUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;

--- a/src/main/java/com/typocreates/gamemodes/commands/GmaCommand.java
+++ b/src/main/java/com/typocreates/gamemodes/commands/GmaCommand.java
@@ -1,5 +1,5 @@
 package com.typocreates.gamemodes.commands;
-import com.typocreates.gamemodes.files.GmLockData;
+import com.typocreates.gamemodes.data.GmLockData;
 import com.typocreates.gamemodes.utils.GeneralUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;

--- a/src/main/java/com/typocreates/gamemodes/commands/GmcCommand.java
+++ b/src/main/java/com/typocreates/gamemodes/commands/GmcCommand.java
@@ -1,5 +1,5 @@
 package com.typocreates.gamemodes.commands;
-import com.typocreates.gamemodes.files.GmLockData;
+import com.typocreates.gamemodes.data.GmLockData;
 import com.typocreates.gamemodes.utils.GeneralUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;

--- a/src/main/java/com/typocreates/gamemodes/commands/GmsCommand.java
+++ b/src/main/java/com/typocreates/gamemodes/commands/GmsCommand.java
@@ -1,5 +1,5 @@
 package com.typocreates.gamemodes.commands;
-import com.typocreates.gamemodes.files.GmLockData;
+import com.typocreates.gamemodes.data.GmLockData;
 import com.typocreates.gamemodes.utils.GeneralUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;

--- a/src/main/java/com/typocreates/gamemodes/commands/GmspCommand.java
+++ b/src/main/java/com/typocreates/gamemodes/commands/GmspCommand.java
@@ -1,5 +1,5 @@
 package com.typocreates.gamemodes.commands;
-import com.typocreates.gamemodes.files.GmLockData;
+import com.typocreates.gamemodes.data.GmLockData;
 import com.typocreates.gamemodes.utils.GeneralUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;

--- a/src/main/java/com/typocreates/gamemodes/data/GmLockData.java
+++ b/src/main/java/com/typocreates/gamemodes/data/GmLockData.java
@@ -1,4 +1,4 @@
-package com.typocreates.gamemodes.files;
+package com.typocreates.gamemodes.data;
 
 import com.typocreates.gamemodes.Gamemodes;
 import org.bukkit.configuration.file.FileConfiguration;

--- a/src/main/java/com/typocreates/gamemodes/data/UpdateCheckResponse.java
+++ b/src/main/java/com/typocreates/gamemodes/data/UpdateCheckResponse.java
@@ -1,0 +1,37 @@
+package com.typocreates.gamemodes.data;
+
+public class UpdateCheckResponse {
+    private final int statusCode;
+    private final String latestVersionNumber;
+    private final String latestVersionTitle;
+    private final String changeLog;
+    private final String[] splitChangeLog;
+
+    public UpdateCheckResponse(int statusCode, String latestVersionNumber, String latestVersionTitle, String changeLog, String[] splitChangeLog) {
+        this.statusCode = statusCode;
+        this.latestVersionNumber = latestVersionNumber;
+        this.latestVersionTitle = latestVersionTitle;
+        this.changeLog = changeLog;
+        this.splitChangeLog = splitChangeLog;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public String getLatestVersionNumber() {
+        return latestVersionNumber;
+    }
+
+    public String getLatestVersionTitle() {
+        return latestVersionTitle;
+    }
+
+    public String getChangeLog() {
+        return changeLog;
+    }
+
+    public String[] getSplitChangeLog() {
+        return splitChangeLog;
+    }
+}

--- a/src/main/java/com/typocreates/gamemodes/listeners/PlayerGamemodeChangeListener.java
+++ b/src/main/java/com/typocreates/gamemodes/listeners/PlayerGamemodeChangeListener.java
@@ -1,6 +1,6 @@
 package com.typocreates.gamemodes.listeners;
 
-import com.typocreates.gamemodes.files.GmLockData;
+import com.typocreates.gamemodes.data.GmLockData;
 import com.typocreates.gamemodes.utils.GeneralUtil;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;

--- a/src/main/java/com/typocreates/gamemodes/listeners/PlayerJoinListener.java
+++ b/src/main/java/com/typocreates/gamemodes/listeners/PlayerJoinListener.java
@@ -1,22 +1,28 @@
 package com.typocreates.gamemodes.listeners;
 
 import com.typocreates.gamemodes.Gamemodes;
+import com.typocreates.gamemodes.data.UpdateCheckResponse;
 import com.typocreates.gamemodes.utils.GeneralUtil;
+import com.typocreates.gamemodes.utils.UpdateChecker;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.logging.Logger;
 
 public class PlayerJoinListener implements Listener {
     private final Gamemodes plugin;
     private final GeneralUtil gu;
+    private final UpdateChecker updateChecker;
 
-    public PlayerJoinListener(Gamemodes plugin, GeneralUtil gu) {
+    public PlayerJoinListener(Gamemodes plugin, GeneralUtil gu, UpdateChecker updateChecker) {
         this.plugin = plugin;
         this.gu = gu;
+        this.updateChecker = updateChecker;
     }
 
     @EventHandler
@@ -32,6 +38,32 @@ public class PlayerJoinListener implements Listener {
                 p.setGameMode(Bukkit.getDefaultGameMode());
                 gu.sendMessage(p, "Your gamemode has been automatically switched! You weren't allowed in your old gamemode!");
             }
+        }
+
+        if (p.hasPermission("gamemodes.notifyupdate")) {
+            Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                CompletableFuture<UpdateCheckResponse> future = updateChecker.getLatestVersion();
+                future.thenAccept((data) -> {
+                    if (!p.isOnline()) {
+                        return;
+                    }
+
+                    if (data.getStatusCode() == 410) {
+                        gu.sendErrorMessage(p, ChatColor.YELLOW + "[Gamemodes] " + ChatColor.RED + "Modrinth had a major update and the update checker has broken! Please check console for details! (A restart may be required to view the issue!");
+                        return;
+                    }
+
+                    if (!data.getLatestVersionNumber().equals(plugin.getDescription().getVersion())) {
+                        gu.sendMessage(p, "[Gamemodes] " + ChatColor.GREEN
+                                + "New version available: "
+                                + ChatColor.GOLD + data.getLatestVersionNumber()
+                                + ChatColor.GREEN + "! Current version: "
+                                + ChatColor.GOLD + plugin.getDescription().getVersion()
+                                + ChatColor.GREEN + "! Download the latest version: "
+                                + ChatColor.GOLD + "https://modrinth.com/project/CD4bmArk");
+                    }
+                });
+            }, 100);
         }
     }
 }

--- a/src/main/java/com/typocreates/gamemodes/utils/UpdateChecker.java
+++ b/src/main/java/com/typocreates/gamemodes/utils/UpdateChecker.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.typocreates.gamemodes.Gamemodes;
+import org.bukkit.Bukkit;
 
 import java.io.IOException;
 import java.net.URI;
@@ -25,61 +26,61 @@ public class UpdateChecker {
         logger.info("Checking for updates...");
         URI uri = URI.create("https://api.modrinth.com/v2/project/CD4bmArk/version?include_changelog=true&version_type=release");
 
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            try (HttpClient client = HttpClient.newHttpClient()) {
+                HttpRequest request = HttpRequest.newBuilder()
+                        .uri(uri)
+                        .GET()
+                        .build();
 
-        try (HttpClient client = HttpClient.newHttpClient()) {
-            HttpRequest request = HttpRequest.newBuilder()
-                    .uri(uri)
-                    .GET()
-                    .build();
+                HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
 
-            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-
-            // Don't continue if the API is deprecated.
-            if (response.statusCode() == 410) {
-                logger.warning("==============================================================================================");
-                logger.warning("The Modrinth API returned status 410! (The API for the update checker!)");
-                logger.warning("This means a major update has occurred to the API which requires an update.");
-                logger.warning("If you don't mind a few errors, this is likely fine. The update checker will be broken though.");
-                logger.warning("To fix this, please check if an update is available for this plugin:");
-                logger.warning("https://modrinth.com/project/CD4bmArk");
-                logger.warning("==============================================================================================");
-                return;
-            }
-
-            Gson gson = new Gson();
-            JsonArray jsonResponse = gson.fromJson(response.body(), JsonArray.class);
-
-            if (jsonResponse.isEmpty()) {
-                logger.warning("Update check failed. Data was either missing or formatted incorrectly.");
-                return;
-            }
-
-            JsonObject latestVersion = jsonResponse.get(0).getAsJsonObject();
-            String latestVersionNumber = latestVersion.get("version_number").getAsString();
-            String versionTitle = latestVersion.get("name").getAsString();
-            String changeLog = latestVersion.get("changelog").getAsString();
-
-            String[] changeLogParts = changeLog
-                    .split("\\n");
-
-            if (!latestVersionNumber.equals(plugin.getDescription().getVersion())) {
-                logger.info("=====================================================================");
-                logger.info("A new version is available for download!");
-                logger.info("Update information:");
-                logger.info(" ");
-                logger.info(versionTitle);
-                for (String line : changeLogParts) {
-                    logger.info(line);
+                // Don't continue if the API is deprecated.
+                if (response.statusCode() == 410) {
+                    logger.warning("==============================================================================================");
+                    logger.warning("The Modrinth API returned status 410! (The API for the update checker!)");
+                    logger.warning("This means a major update has occurred to the API which requires an update.");
+                    logger.warning("If you don't mind a few errors, this is likely fine. The update checker will be broken though.");
+                    logger.warning("To fix this, please check if an update is available for this plugin:");
+                    logger.warning("https://modrinth.com/project/CD4bmArk");
+                    logger.warning("==============================================================================================");
+                    return;
                 }
-                logger.info(" ");
-                logger.info("Download the update here: https://modrinth.com/project/CD4bmArk");
-                logger.info("=====================================================================");
-            } else {
-                logger.info("Update check complete, no updates needed!");
-            }
-        } catch (IOException | InterruptedException e) {
-            logger.warning("Failed to check for updates! " + e.getMessage());
-        }
 
+                Gson gson = new Gson();
+                JsonArray jsonResponse = gson.fromJson(response.body(), JsonArray.class);
+
+                if (jsonResponse.isEmpty()) {
+                    logger.warning("Update check failed. Data was either missing or formatted incorrectly.");
+                    return;
+                }
+
+                JsonObject latestVersion = jsonResponse.get(0).getAsJsonObject();
+                String latestVersionNumber = latestVersion.get("version_number").getAsString();
+                String versionTitle = latestVersion.get("name").getAsString();
+                String changeLog = latestVersion.get("changelog").getAsString();
+
+                String[] changeLogParts = changeLog
+                        .split("\\n");
+
+                if (!latestVersionNumber.equals(plugin.getDescription().getVersion())) {
+                    logger.info("=====================================================================");
+                    logger.info("A new version is available for download!");
+                    logger.info("Update information:");
+                    logger.info(" ");
+                    logger.info(versionTitle);
+                    for (String line : changeLogParts) {
+                        logger.info(line);
+                    }
+                    logger.info(" ");
+                    logger.info("Download the update here: https://modrinth.com/project/CD4bmArk");
+                    logger.info("=====================================================================");
+                } else {
+                    logger.info("Update check complete, no updates needed!");
+                }
+            } catch (IOException | InterruptedException e) {
+                logger.warning("Failed to check for updates! " + e.getMessage());
+            }
+        });
     }
 }

--- a/src/main/java/com/typocreates/gamemodes/utils/UpdateChecker.java
+++ b/src/main/java/com/typocreates/gamemodes/utils/UpdateChecker.java
@@ -4,13 +4,14 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.typocreates.gamemodes.Gamemodes;
-import org.bukkit.Bukkit;
+import com.typocreates.gamemodes.data.UpdateCheckResponse;
 
-import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 public class UpdateChecker {
@@ -24,35 +25,59 @@ public class UpdateChecker {
     public void checkUpdate() {
         Logger logger = plugin.getLogger();
         logger.info("Checking for updates...");
+        CompletableFuture<UpdateCheckResponse> future = getLatestVersion();
+
+        future.thenAccept((data) -> {
+            if (data.getStatusCode() == 410) {
+                logger.warning("==============================================================================================");
+                logger.warning("The Modrinth API returned status 410! (The API for the update checker!)");
+                logger.warning("This means a major update has occurred to the API which requires an update.");
+                logger.warning("If you don't mind a few errors, this is likely fine. The update checker will be broken though.");
+                logger.warning("To fix this, please check if an update is available for this plugin:");
+                logger.warning("https://modrinth.com/project/CD4bmArk");
+                logger.warning("==============================================================================================");
+                return;
+            }
+
+            if (!data.getLatestVersionNumber().equals(plugin.getDescription().getVersion())) {
+                logger.info("=====================================================================");
+                logger.info("A new version is available for download!");
+                logger.info("Update information:");
+                logger.info(" ");
+                logger.info(data.getLatestVersionTitle());
+                for (String line : data.getSplitChangeLog()) {
+                    logger.info(line);
+                }
+                logger.info(" ");
+                logger.info("Download the update here: https://modrinth.com/project/CD4bmArk");
+                logger.info("=====================================================================");
+            } else {
+                logger.info("Update check complete, no updates needed!");
+            }
+        });
+    }
+
+    public CompletableFuture<UpdateCheckResponse> getLatestVersion() {
+        Logger logger = plugin.getLogger();
         URI uri = URI.create("https://api.modrinth.com/v2/project/CD4bmArk/version?include_changelog=true&version_type=release");
 
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-            try (HttpClient client = HttpClient.newHttpClient()) {
-                HttpRequest request = HttpRequest.newBuilder()
-                        .uri(uri)
-                        .GET()
-                        .build();
-
-                HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-
-                // Don't continue if the API is deprecated.
-                if (response.statusCode() == 410) {
-                    logger.warning("==============================================================================================");
-                    logger.warning("The Modrinth API returned status 410! (The API for the update checker!)");
-                    logger.warning("This means a major update has occurred to the API which requires an update.");
-                    logger.warning("If you don't mind a few errors, this is likely fine. The update checker will be broken though.");
-                    logger.warning("To fix this, please check if an update is available for this plugin:");
-                    logger.warning("https://modrinth.com/project/CD4bmArk");
-                    logger.warning("==============================================================================================");
-                    return;
-                }
-
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(uri)
+                    .GET()
+                    .build();
+            CompletableFuture<HttpResponse<String>> response = client.sendAsync(request, HttpResponse.BodyHandlers.ofString()).orTimeout(5, TimeUnit.SECONDS);
+            response.exceptionally((e) -> {
+                logger.warning("Unable to check for updates! Do you have an internet connection?");
+                logger.warning(e.getMessage());
+                return null;
+            });
+            return response.thenApply((r) -> {
                 Gson gson = new Gson();
-                JsonArray jsonResponse = gson.fromJson(response.body(), JsonArray.class);
+                JsonArray jsonResponse = gson.fromJson(r.body(), JsonArray.class);
 
                 if (jsonResponse.isEmpty()) {
-                    logger.warning("Update check failed. Data was either missing or formatted incorrectly.");
-                    return;
+                    return null;
                 }
 
                 JsonObject latestVersion = jsonResponse.get(0).getAsJsonObject();
@@ -60,27 +85,11 @@ public class UpdateChecker {
                 String versionTitle = latestVersion.get("name").getAsString();
                 String changeLog = latestVersion.get("changelog").getAsString();
 
-                String[] changeLogParts = changeLog
+                String[] splitChangeLog = changeLog
                         .split("\\n");
 
-                if (!latestVersionNumber.equals(plugin.getDescription().getVersion())) {
-                    logger.info("=====================================================================");
-                    logger.info("A new version is available for download!");
-                    logger.info("Update information:");
-                    logger.info(" ");
-                    logger.info(versionTitle);
-                    for (String line : changeLogParts) {
-                        logger.info(line);
-                    }
-                    logger.info(" ");
-                    logger.info("Download the update here: https://modrinth.com/project/CD4bmArk");
-                    logger.info("=====================================================================");
-                } else {
-                    logger.info("Update check complete, no updates needed!");
-                }
-            } catch (IOException | InterruptedException e) {
-                logger.warning("Failed to check for updates! " + e.getMessage());
-            }
-        });
+                return new UpdateCheckResponse(r.statusCode(), latestVersionNumber, versionTitle, changeLog, splitChangeLog);
+            });
+        }
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -38,7 +38,7 @@ permissions:
       gamemodes.gmsp: true
 
   gamemodes.notifyupdate:
-    description: Players with this permission will be notified in chat upon joining if an update is available.
+    description: Players with this permission will be notified in chat upon joining when an update is available.
 
   gamemodes.gma:
     description: Allows the player to use the /gma <player> command.

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -37,6 +37,9 @@ permissions:
       gamemodes.gms: true
       gamemodes.gmsp: true
 
+  gamemodes.notifyupdate:
+    description: Players with this permission will be notified in chat upon joining if an update is available.
+
   gamemodes.gma:
     description: Allows the player to use the /gma <player> command.
 


### PR DESCRIPTION
Once this PR is done, it will add the feature to notify players with a specific permission when an update becomes available (Checked when they join the server)

To add this, the following needs to be done

- The update checker needs to be asynchronous
- The logging to console in the update checker needs to be separated from the actual update check (so that the server console doesn't get flooded every time someone with the permission for update checks joins)
- While not mandatory, it would be ideal if some type of storage was added to save if an update is available, then update that every so often, that way we aren't hitting the Modrinth API every single time someone joins with the permission


This PR seeks to do all the above, and add a notifier for when admins join the server